### PR TITLE
Threshold fix

### DIFF
--- a/math/persistence_updater.h
+++ b/math/persistence_updater.h
@@ -160,7 +160,7 @@ private:
     void store_barcode_template(std::shared_ptr<Face> cell);
 
     //chooses an initial threshold by timing vineyard updates corresponding to random transpositions
-    unsigned long choose_initial_threshold(unsigned decomp_time, unsigned long & num_trans, unsigned & trans_time);
+    void choose_initial_threshold(unsigned decomp_time, unsigned long & num_trans, unsigned & trans_time, unsigned long & threshold);
 
     ///TESTING ONLY
     //void check_low_matrix(MapMatrix_Perm* RL, MapMatrix_RowPriority_Perm* UL);

--- a/math/persistence_updater.h
+++ b/math/persistence_updater.h
@@ -160,7 +160,7 @@ private:
     void store_barcode_template(std::shared_ptr<Face> cell);
 
     //chooses an initial threshold by timing vineyard updates corresponding to random transpositions
-    unsigned long choose_initial_threshold(int time_for_initial_decomp);
+    unsigned long choose_initial_threshold(unsigned decomp_time, unsigned long & num_trans, unsigned & trans_time);
 
     ///TESTING ONLY
     //void check_low_matrix(MapMatrix_Perm* RL, MapMatrix_RowPriority_Perm* UL);

--- a/math/template_points_matrix.cpp
+++ b/math/template_points_matrix.cpp
@@ -119,20 +119,19 @@ bool Multigrade::LexComparator(const Multigrade& first, const Multigrade& second
     return first.x > second.x || (first.x == second.x && first.y > second.y);
 }
 
-/********** xiSupportMatrix **********/
+/********** TemplatePointsMatrix **********/
 
-//constructor for xiSupportMatrix
+//constructor for TemplatePointsMatrix
 TemplatePointsMatrix::TemplatePointsMatrix(unsigned width, unsigned height)
     : columns(width)
     , rows(height)
 {
 }
 
-//stores the supplied xi support points in the xiSupportMatrix
-//  also finds anchors, which are stored in the matrix, the vector xi_pts, AND in the Arrangement
+//stores the supplied xi support points in the TemplatePointsMatrix
+//  also finds anchors, which are stored in the matrix and in the vector xi_pts
 //  precondition: xi_pts contains the support points in lexicographical order
-///NOTE: WRITTEN FOR JULY 2015 BUG FIX
-///      Runtime complexity of this function is O(n_x * n_y). We can probably do better, but it probably doesn't matter.
+//  Runtime complexity of this function is O(n_x * n_y). We can probably do better, but it probably doesn't matter.
 std::vector<std::shared_ptr<TemplatePointsMatrixEntry>> TemplatePointsMatrix::fill_and_find_anchors(std::vector<TemplatePoint>& xi_pts)
 {
     unsigned next_xi_pt = 0; //tracks the index of the next xi support point to insert


### PR DESCRIPTION
Regarding the extremely large threshold that Mike reported: this appears to be the result of a floating-point division by zero. I have restored the changes from commit fc7f087 (June 7, 2016), which fix this bug. These changes are:

- PersistenceUpdater::choose_initial_threshold(...) returns the number of transpositions and runtime, and these quantities are used in later threshold calculations.
- PersistenceUpdater::choose_initial_threshold(...) does random vineyard updates until one of the following conditions occurs:
- Elapsed time exceeds 100 milliseconds (or 1/20 of initial decomposition time) and at least one vineyard update has been performed
- Elapsed time exceeds 5 milliseconds and 5000 vineyard updates have been performed
- PersistenceUpdater::choose_initial_threshold(...) does not copy the matrices -- we had agreed that this was unnecessary since the function "undoes" all of the vineyard updates that it performs.

I also added an if statement (persistence_updater.cpp line 314) so that the threshold is only updated at each step of the path if either vineyard updates or a reset are performed. This if statement isn't really necessary, since if neither vineyard updates nor a reset occurs, then the quantities involved in the threshold calculation will be the same as at the previous step, so the threshold won't change; however, it may be slightly faster to process the if statement than to recompute the threshold in this situation.